### PR TITLE
Revert "refactor(operations): use full names for operation types (#128)"

### DIFF
--- a/internal/connectors/db/process_result_set.go
+++ b/internal/connectors/db/process_result_set.go
@@ -209,7 +209,7 @@ func ReadOperationFromResultSet(res query.Row) (types.Operation, error) {
 		updatedTs = timestamppb.New(*updatedAt)
 	}
 
-	if operationType == string(types.LegacyOperationTypeTB) || operationType == string(types.OperationTypeTB) {
+	if operationType == string(types.OperationTypeTB) {
 		if backupId == nil {
 			return nil, fmt.Errorf("failed to read backup_id for TB operation: %s", operationId)
 		}
@@ -230,7 +230,7 @@ func ReadOperationFromResultSet(res query.Row) (types.Operation, error) {
 			UpdatedAt:            updatedTs,
 			ParentOperationID:    parentOperationID,
 		}, nil
-	} else if operationType == string(types.LegacyOperationTypeRB) || operationType == string(types.OperationTypeRB) {
+	} else if operationType == string(types.OperationTypeRB) {
 		if backupId == nil {
 			return nil, fmt.Errorf("failed to read backup_id for RB operation: %s", operationId)
 		}
@@ -249,7 +249,7 @@ func ReadOperationFromResultSet(res query.Row) (types.Operation, error) {
 			Audit:          auditFromDb(creator, createdAt, completedAt),
 			UpdatedAt:      updatedTs,
 		}, nil
-	} else if operationType == string(types.LegacyOperationTypeDB) || operationType == string(types.OperationTypeDB) {
+	} else if operationType == string(types.OperationTypeDB) {
 		if backupId == nil {
 			return nil, fmt.Errorf("failed to read backup_id for DB operation: %s", operationId)
 		}
@@ -273,7 +273,7 @@ func ReadOperationFromResultSet(res query.Row) (types.Operation, error) {
 			PathPrefix: pathPrefix,
 			UpdatedAt:  updatedTs,
 		}, nil
-	} else if operationType == string(types.LegacyOperationTypeTBWR) || operationType == string(types.OperationTypeTBWR) {
+	} else if operationType == string(types.OperationTypeTBWR) {
 		var retryConfig *pb.RetryConfig = nil
 		if maxBackoff != nil {
 			retryConfig = &pb.RetryConfig{

--- a/internal/connectors/db/yql/queries/write_test.go
+++ b/internal/connectors/db/yql/queries/write_test.go
@@ -123,7 +123,7 @@ UPSERT INTO Operations (id, type, status, message, initiated, created_at, contai
 			),
 
 			table.ValueParam("$id_1", table_types.StringValueFromString(opId)),
-			table.ValueParam("$type_1", table_types.StringValueFromString(types.OperationTypeTB.String())),
+			table.ValueParam("$type_1", table_types.StringValueFromString("TB")),
 			table.ValueParam(
 				"$status_1", table_types.StringValueFromString(string(tbOp.State)),
 			),
@@ -209,7 +209,7 @@ UPSERT INTO Operations (id, type, status, message, initiated, created_at, contai
 			table.ValueParam("$message_0", table_types.StringValueFromString("Success")),
 			table.ValueParam("$expire_at_0", table_types.NullableTimestampValueFromTime(nil)),
 			table.ValueParam("$id_1", table_types.StringValueFromString(opId)),
-			table.ValueParam("$type_1", table_types.StringValueFromString(types.OperationTypeTB.String())),
+			table.ValueParam("$type_1", table_types.StringValueFromString("TB")),
 			table.ValueParam(
 				"$status_1", table_types.StringValueFromString(string(tbOp.State)),
 			),

--- a/internal/types/operation.go
+++ b/internal/types/operation.go
@@ -434,20 +434,11 @@ var (
 	OperationStateStartCancelling = OperationState(pb.Operation_START_CANCELLING.String())
 )
 
-// Deprecated: these short operation type names are unclear and will be removed in the future. Use full names instead.
 const (
-	LegacyOperationTypeTB   = OperationType("TB")
-	LegacyOperationTypeRB   = OperationType("RB")
-	LegacyOperationTypeDB   = OperationType("DB")
-	LegacyOperationTypeTBWR = OperationType("TBWR")
-)
-
-const (
-	OperationTypeTB   = OperationType("TakeBackup")
-	OperationTypeRB   = OperationType("RestoreBackup")
-	OperationTypeDB   = OperationType("DeleteBackup")
-	OperationTypeTBWR = OperationType("TakeBackupWithRetries")
-
+	OperationTypeTB       = OperationType("TB")
+	OperationTypeRB       = OperationType("RB")
+	OperationTypeDB       = OperationType("DB")
+	OperationTypeTBWR     = OperationType("TBWR")
 	BackupTimestampFormat = "20060102_150405"
 	OperationCreatorName  = "ydbcp"
 )


### PR DESCRIPTION
This reverts commit 90afa3a9884965b4aaac3ef2a787757fd73ca69f.